### PR TITLE
fix: downgrade BUNDLED WITH to 2.7.2 for buildpack compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,4 +109,4 @@ RUBY VERSION
   ruby 3.4.8
 
 BUNDLED WITH
-  4.0.11
+  2.7.2


### PR DESCRIPTION
## Summary

- Downgrade `BUNDLED WITH` in `Gemfile.lock` from `4.0.11` → `2.7.2`
- Fixes `BuildpackCompileFailed` in upgrade tests on TAS 10.0 and TAS 10.3

## Root cause

The CF ruby buildpack resolves bundler from its **offline cache**. Each TAS version ships a frozen buildpack:

| Buildpack | TAS | Bundler in cache | Behaviour with `BUNDLED WITH 4.0.11` |
|-----------|-----|-----------------|--------------------------------------|
| 1.10.35 | 10.0 | 2.6.8 | FAIL — major version downgrade (2→4) |
| 1.10.70 | 10.3 | 2.7.2 | FAIL — major version downgrade (2→4) |
| 1.10.72 | 10.2/10.4 | 4.0.10 | PASS — same major, minor diff |

## Fix

`BUNDLED WITH 2.7.2` satisfies all three caches:

| Buildpack | Bundler in cache | Result |
|-----------|-----------------|--------|
| 1.10.35 (TAS 10.0) | 2.6.8 | WARN + PASS (proven empirically — minor mismatch tolerated) |
| 1.10.70 (TAS 10.3) | 2.7.2 | Exact match ✓ |
| 1.10.72 (TAS 10.2/10.4) | 4.0.10 | Forward-compatible: 4.0.10 ≥ 2.7.2 ✓ |

Ruby version (`~> 3.4.0`) is unchanged — all three buildpacks have ruby 3.4.x in cache.

## Test plan

- [ ] Trigger `rabbitmq-10.4/test-upgrade-product-previous-minor-10_0` — should pass
- [ ] Trigger `rabbitmq-10.4/test-upgrade-product-previous-minor-10_3` — should pass
- [ ] Confirm `rabbitmq-10.4/test-upgrade-product-previous-minor-10_2` and `10_4` still pass